### PR TITLE
removed unused parameter 'commentFormat'

### DIFF
--- a/src/main/java/org/apache/maven/plugin/changelog/ChangeLogReport.java
+++ b/src/main/java/org/apache/maven/plugin/changelog/ChangeLogReport.java
@@ -178,14 +178,6 @@ public class ChangeLogReport
     private int outputXMLExpiration;
 
     /**
-     * Comment format string used for interrogating
-     * the revision control system.
-     * Currently only used by the ClearcaseChangeLogGenerator.
-     */
-    @Parameter( property = "changelog.commentFormat" )
-    private String commentFormat;
-
-    /**
      * The file encoding when writing non-HTML reports.
      */
     @Parameter( property = "changelog.outputEncoding", defaultValue = "${project.reporting.outputEncoding}" )


### PR DESCRIPTION
The parameter `commentFormat` on the changelog mojo is unused and the javadoc says that it is used by `ClearcaseChangeLogGenerator` which not exists on the project.